### PR TITLE
Add module with description builder

### DIFF
--- a/Assets/UGF.Application.Editor.Tests/TestModule.cs
+++ b/Assets/UGF.Application.Editor.Tests/TestModule.cs
@@ -4,5 +4,8 @@ namespace UGF.Application.Editor.Tests
 {
     public class TestModule : ApplicationModuleBase
     {
+        public TestModule(IApplication application) : base(application)
+        {
+        }
     }
 }

--- a/Assets/UGF.Application.Editor.Tests/TestModuleAsset.cs
+++ b/Assets/UGF.Application.Editor.Tests/TestModuleAsset.cs
@@ -12,7 +12,7 @@ namespace UGF.Application.Editor.Tests
 
         protected override TestModule OnBuildTyped(IApplication application)
         {
-            return new TestModule();
+            return new TestModule(application);
         }
     }
 }

--- a/Assets/UGF.Application.Runtime.Tests/New Test Described Module Asset.asset
+++ b/Assets/UGF.Application.Runtime.Tests/New Test Described Module Asset.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c5e67fe8a97f4c2f83f7ce29775e7cd2, type: 3}
+  m_Name: New Test Described Module Asset
+  m_EditorClassIdentifier: 

--- a/Assets/UGF.Application.Runtime.Tests/New Test Described Module Asset.asset.meta
+++ b/Assets/UGF.Application.Runtime.Tests/New Test Described Module Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b01d40a7ee390814c865fd62969e3987
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Application.Runtime.Tests/TestApplicationBase.cs
+++ b/Assets/UGF.Application.Runtime.Tests/TestApplicationBase.cs
@@ -17,13 +17,16 @@ namespace UGF.Application.Runtime.Tests
 
         private class Module : ApplicationModuleBase, IModule
         {
+            public Module(IApplication application) : base(application)
+            {
+            }
         }
 
         [Test]
         public void Modules()
         {
             var application = new Application();
-            var module = new Module();
+            var module = new Module(application);
 
             application.AddModule<IModule>(module);
 
@@ -35,8 +38,8 @@ namespace UGF.Application.Runtime.Tests
         public void OnInitialize()
         {
             var application = new Application();
-            var module0 = new Module();
-            var module1 = new Module();
+            var module0 = new Module(application);
+            var module1 = new Module(application);
 
             application.AddModule<IModule>(module0);
             application.AddModule<IApplicationModule>(module1);
@@ -50,8 +53,8 @@ namespace UGF.Application.Runtime.Tests
         public void OnUninitialize()
         {
             var application = new Application();
-            var module0 = new Module();
-            var module1 = new Module();
+            var module0 = new Module(application);
+            var module1 = new Module(application);
 
             application.AddModule<IModule>(module0);
             application.AddModule<IApplicationModule>(module1);
@@ -66,7 +69,7 @@ namespace UGF.Application.Runtime.Tests
         public void AddModule()
         {
             var application = new Application();
-            var module = new Module();
+            var module = new Module(application);
 
             Assert.AreEqual(0, application.Count);
 
@@ -80,7 +83,7 @@ namespace UGF.Application.Runtime.Tests
         public void RemoveModule()
         {
             var application = new Application();
-            var module = new Module();
+            var module = new Module(application);
 
             Assert.AreEqual(0, application.Count);
 
@@ -99,7 +102,7 @@ namespace UGF.Application.Runtime.Tests
         public void ClearModules()
         {
             var application = new Application();
-            var module = new Module();
+            var module = new Module(application);
 
             Assert.AreEqual(0, application.Count);
 
@@ -118,7 +121,7 @@ namespace UGF.Application.Runtime.Tests
         public void GetModule()
         {
             var application = new Application();
-            var module0 = new Module();
+            var module0 = new Module(application);
 
             application.AddModule<IModule>(module0);
 
@@ -132,7 +135,7 @@ namespace UGF.Application.Runtime.Tests
         public void TryGetModule()
         {
             var application = new Application();
-            var module0 = new Module();
+            var module0 = new Module(application);
 
             application.AddModule<IModule>(module0);
 

--- a/Assets/UGF.Application.Runtime.Tests/TestApplicationLauncher.cs
+++ b/Assets/UGF.Application.Runtime.Tests/TestApplicationLauncher.cs
@@ -27,10 +27,10 @@ namespace UGF.Application.Runtime.Tests
                 Assert.True(IsLaunched);
                 Assert.False(HasApplication);
 
-                m_module = new Module();
-                m_moduleAsync = new ModuleAsync();
-
                 var application = new Application();
+
+                m_module = new Module(application);
+                m_moduleAsync = new ModuleAsync(application);
 
                 application.AddModule(m_module);
                 application.AddModule(m_moduleAsync);
@@ -88,6 +88,10 @@ namespace UGF.Application.Runtime.Tests
         {
             public bool IsInit { get; private set; }
 
+            public Module(IApplication application) : base(application)
+            {
+            }
+
             protected override void OnInitialize()
             {
                 base.OnInitialize();
@@ -106,6 +110,10 @@ namespace UGF.Application.Runtime.Tests
         private class ModuleAsync : ApplicationModuleBase, IApplicationModuleAsync
         {
             public bool IsInit { get; private set; }
+
+            public ModuleAsync(IApplication application) : base(application)
+            {
+            }
 
             public async Task InitializeAsync()
             {

--- a/Assets/UGF.Application.Runtime.Tests/TestDescribedModuleAsset.cs
+++ b/Assets/UGF.Application.Runtime.Tests/TestDescribedModuleAsset.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using UnityEngine;
+
+namespace UGF.Application.Runtime.Tests
+{
+    [CreateAssetMenu(menuName = "Tests/TestDescribedModuleAsset")]
+    public class TestDescribedModuleAsset : ApplicationModuleDescribedAsset<TestDescribedModule, TestModuleDescription>
+    {
+        protected override TestModuleDescription OnGetDescription(IApplication application)
+        {
+            return new TestModuleDescription();
+        }
+
+        protected override TestDescribedModule OnBuild(IApplication application, TestModuleDescription description)
+        {
+            return new TestDescribedModule(description);
+        }
+    }
+
+    public class TestDescribedModule : ApplicationModuleBase
+    {
+        public TestModuleDescription Description { get; }
+
+        public TestDescribedModule(TestModuleDescription description)
+        {
+            Description = description ?? throw new ArgumentNullException(nameof(description));
+        }
+    }
+
+    public class TestModuleDescription : IApplicationModuleDescription
+    {
+    }
+}

--- a/Assets/UGF.Application.Runtime.Tests/TestDescribedModuleAsset.cs
+++ b/Assets/UGF.Application.Runtime.Tests/TestDescribedModuleAsset.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace UGF.Application.Runtime.Tests
 {
@@ -13,17 +12,14 @@ namespace UGF.Application.Runtime.Tests
 
         protected override TestDescribedModule OnBuild(IApplication application, TestModuleDescription description)
         {
-            return new TestDescribedModule(description);
+            return new TestDescribedModule(application, description);
         }
     }
 
-    public class TestDescribedModule : ApplicationModuleBase
+    public class TestDescribedModule : ApplicationModuleDescribed<TestModuleDescription>
     {
-        public TestModuleDescription Description { get; }
-
-        public TestDescribedModule(TestModuleDescription description)
+        public TestDescribedModule(IApplication application, TestModuleDescription description) : base(application, description)
         {
-            Description = description ?? throw new ArgumentNullException(nameof(description));
         }
     }
 

--- a/Assets/UGF.Application.Runtime.Tests/TestDescribedModuleAsset.cs.meta
+++ b/Assets/UGF.Application.Runtime.Tests/TestDescribedModuleAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c5e67fe8a97f4c2f83f7ce29775e7cd2
+timeCreated: 1603384733

--- a/Packages/UGF.Application/Runtime/ApplicationBase.cs
+++ b/Packages/UGF.Application/Runtime/ApplicationBase.cs
@@ -57,6 +57,7 @@ namespace UGF.Application.Runtime
         {
             if (registerType == null) throw new ArgumentNullException(nameof(registerType));
             if (module == null) throw new ArgumentNullException(nameof(module));
+            if (module.Application != this) throw new ArgumentException($"Can not add module from another application: '{module.Application}'.");
 
             OnAddModule(registerType, module);
         }

--- a/Packages/UGF.Application/Runtime/ApplicationModuleBase.cs
+++ b/Packages/UGF.Application/Runtime/ApplicationModuleBase.cs
@@ -1,3 +1,4 @@
+using System;
 using UGF.Initialize.Runtime;
 
 namespace UGF.Application.Runtime
@@ -7,5 +8,11 @@ namespace UGF.Application.Runtime
     /// </summary>
     public abstract class ApplicationModuleBase : InitializeBase, IApplicationModule
     {
+        public IApplication Application { get; }
+
+        protected ApplicationModuleBase(IApplication application)
+        {
+            Application = application ?? throw new ArgumentNullException(nameof(application));
+        }
     }
 }

--- a/Packages/UGF.Application/Runtime/ApplicationModuleDescribed.cs
+++ b/Packages/UGF.Application/Runtime/ApplicationModuleDescribed.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace UGF.Application.Runtime
+{
+    public class ApplicationModuleDescribed<TDescription> : ApplicationModuleBase, IApplicationModuleDescribed where TDescription : class, IApplicationModuleDescription
+    {
+        public TDescription Description { get; }
+
+        IApplicationModuleDescription IApplicationModuleDescribed.Description { get { return Description; } }
+
+        public ApplicationModuleDescribed(IApplication application, TDescription description) : base(application)
+        {
+            Description = description ?? throw new ArgumentNullException(nameof(description));
+        }
+    }
+}

--- a/Packages/UGF.Application/Runtime/ApplicationModuleDescribed.cs.meta
+++ b/Packages/UGF.Application/Runtime/ApplicationModuleDescribed.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b25290ba60cd4c42a5329937ac5e0948
+timeCreated: 1603385571

--- a/Packages/UGF.Application/Runtime/ApplicationModuleDescribedAsset.cs
+++ b/Packages/UGF.Application/Runtime/ApplicationModuleDescribedAsset.cs
@@ -3,7 +3,7 @@
 namespace UGF.Application.Runtime
 {
     public abstract class ApplicationModuleDescribedAsset<TModule, TDescription> : ApplicationModuleAsset<TModule>, IApplicationModuleDescriptionAsset
-        where TModule : class, IApplicationModule
+        where TModule : class, IApplicationModuleDescribed
         where TDescription : class, IApplicationModuleDescription
     {
         public T GetGetDescription<T>(IApplication application) where T : class, IApplicationModuleDescription

--- a/Packages/UGF.Application/Runtime/ApplicationModuleDescribedAsset.cs
+++ b/Packages/UGF.Application/Runtime/ApplicationModuleDescribedAsset.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+namespace UGF.Application.Runtime
+{
+    public abstract class ApplicationModuleDescribedAsset<TModule, TDescription> : ApplicationModuleAsset<TModule>, IApplicationModuleDescriptionAsset
+        where TModule : class, IApplicationModule
+        where TDescription : class, IApplicationModuleDescription
+    {
+        public T GetGetDescription<T>(IApplication application) where T : class, IApplicationModuleDescription
+        {
+            IApplicationModuleDescription description = GetDescription(application);
+
+            return (T)description;
+        }
+
+        public TDescription GetDescription(IApplication application)
+        {
+            if (application == null) throw new ArgumentNullException(nameof(application));
+
+            return OnGetDescription(application);
+        }
+
+        protected override TModule OnBuildTyped(IApplication application)
+        {
+            TDescription description = GetDescription(application);
+            TModule module = OnBuild(application, description);
+
+            return module;
+        }
+
+        protected abstract TDescription OnGetDescription(IApplication application);
+        protected abstract TModule OnBuild(IApplication application, TDescription description);
+
+        IApplicationModuleDescription IApplicationModuleDescriptionAsset.GetDescription(IApplication application)
+        {
+            return GetDescription(application);
+        }
+    }
+}

--- a/Packages/UGF.Application/Runtime/ApplicationModuleDescribedAsset.cs.meta
+++ b/Packages/UGF.Application/Runtime/ApplicationModuleDescribedAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d6c21a0161c7415d845187f7c4be5d4a
+timeCreated: 1603384085

--- a/Packages/UGF.Application/Runtime/ApplicationModuleDescriptionBase.cs
+++ b/Packages/UGF.Application/Runtime/ApplicationModuleDescriptionBase.cs
@@ -1,0 +1,6 @@
+﻿namespace UGF.Application.Runtime
+{
+    public abstract class ApplicationModuleDescriptionBase : IApplicationModuleDescription
+    {
+    }
+}

--- a/Packages/UGF.Application/Runtime/ApplicationModuleDescriptionBase.cs.meta
+++ b/Packages/UGF.Application/Runtime/ApplicationModuleDescriptionBase.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5a13707b0cf54e25afdeaf1618be6a86
+timeCreated: 1603390453

--- a/Packages/UGF.Application/Runtime/IApplicationModule.cs
+++ b/Packages/UGF.Application/Runtime/IApplicationModule.cs
@@ -7,5 +7,6 @@ namespace UGF.Application.Runtime
     /// </summary>
     public interface IApplicationModule : IInitialize
     {
+        IApplication Application { get; }
     }
 }

--- a/Packages/UGF.Application/Runtime/IApplicationModuleDescribed.cs
+++ b/Packages/UGF.Application/Runtime/IApplicationModuleDescribed.cs
@@ -1,0 +1,7 @@
+﻿namespace UGF.Application.Runtime
+{
+    public interface IApplicationModuleDescribed : IApplicationModule
+    {
+        IApplicationModuleDescription Description { get; }
+    }
+}

--- a/Packages/UGF.Application/Runtime/IApplicationModuleDescribed.cs.meta
+++ b/Packages/UGF.Application/Runtime/IApplicationModuleDescribed.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 983049d8081c4b119631a1d74d46b5c7
+timeCreated: 1603385623

--- a/Packages/UGF.Application/Runtime/IApplicationModuleDescription.cs
+++ b/Packages/UGF.Application/Runtime/IApplicationModuleDescription.cs
@@ -1,0 +1,6 @@
+﻿namespace UGF.Application.Runtime
+{
+    public interface IApplicationModuleDescription
+    {
+    }
+}

--- a/Packages/UGF.Application/Runtime/IApplicationModuleDescription.cs.meta
+++ b/Packages/UGF.Application/Runtime/IApplicationModuleDescription.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 700c3554420e4f4c988029222b63f2cf
+timeCreated: 1603384021

--- a/Packages/UGF.Application/Runtime/IApplicationModuleDescriptionAsset.cs
+++ b/Packages/UGF.Application/Runtime/IApplicationModuleDescriptionAsset.cs
@@ -1,0 +1,8 @@
+﻿namespace UGF.Application.Runtime
+{
+    public interface IApplicationModuleDescriptionAsset
+    {
+        T GetGetDescription<T>(IApplication application) where T : class, IApplicationModuleDescription;
+        IApplicationModuleDescription GetDescription(IApplication application);
+    }
+}

--- a/Packages/UGF.Application/Runtime/IApplicationModuleDescriptionAsset.cs.meta
+++ b/Packages/UGF.Application/Runtime/IApplicationModuleDescriptionAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1c4a1655aa3947828bf89783d9c0505f
+timeCreated: 1603384178

--- a/Packages/UGF.Application/package.json
+++ b/Packages/UGF.Application/package.json
@@ -24,6 +24,6 @@
     "dependencies": {
         "com.ugf.initialize": "2.4.0",
         "com.ugf.customsettings": "3.0.1",
-        "com.ugf.editortools": "1.4.1"
+        "com.ugf.editortools": "1.5.1"
     }
 }

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "com.ugf.initialize": "2.4.0",
         "com.ugf.customsettings": "3.0.1",
-        "com.ugf.editortools": "1.4.1"
+        "com.ugf.editortools": "1.5.1"
       }
     },
     "com.ugf.customsettings": {
@@ -20,7 +20,7 @@
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.editortools": {
-      "version": "1.4.1",
+      "version": "1.5.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {},


### PR DESCRIPTION
- Add `ApplicationModuleDescribed<T>` an application module default implementation with typed description.
- Add `ApplicationModuleDescribedAsset` scriptableobject asset to define module creation with description.
- Add `IApplicationModule.Application` property to access to application.
- Add `IApplicationModuleDescribed`, `IApplicationModuleDescription`, `IApplicationModuleDescriptionAsset` to implement custom described application module.
- Change `ApplicationModuleBase` to always have `Application` from creation.
- Update package dependencies: `com.ugf.editortools` to `1.5.1`.