### PR TITLE
Change ApplicationModuleDescription constructor

### DIFF
--- a/Packages/UGF.Application/Runtime/ApplicationModuleDescription.cs
+++ b/Packages/UGF.Application/Runtime/ApplicationModuleDescription.cs
@@ -4,7 +4,11 @@ namespace UGF.Application.Runtime
 {
     public class ApplicationModuleDescription : IApplicationModuleDescription
     {
-        public Type RegisterType { get; }
+        public Type RegisterType { get; set; }
+
+        public ApplicationModuleDescription()
+        {
+        }
 
         public ApplicationModuleDescription(Type registerType)
         {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.0f1
-m_EditorVersionWithRevision: 2020.2.0f1 (3721df5a8b28)
+m_EditorVersion: 2020.2.1f1
+m_EditorVersionWithRevision: 2020.2.1f1 (270dd8c3da1c)


### PR DESCRIPTION
- Add default constructor for `ApplicationModuleDescription` class, and constructor with `registerType` argument not recommended to use.
- Change `RegisterType` property to be read and write.