### PR TITLE
Add obsolete attribute for ApplicationModuleDescription constructor with register type

### DIFF
--- a/Assets/UGF.Application.Runtime.Tests/TestApplicationBase.cs
+++ b/Assets/UGF.Application.Runtime.Tests/TestApplicationBase.cs
@@ -17,7 +17,7 @@ namespace UGF.Application.Runtime.Tests
 
         private class Module : ApplicationModule<ApplicationModuleDescription>, IModule
         {
-            public Module(IApplication application) : base(new ApplicationModuleDescription(typeof(IModule)), application)
+            public Module(IApplication application) : base(new ApplicationModuleDescription { RegisterType = typeof(IModule) }, application)
             {
             }
         }

--- a/Assets/UGF.Application.Runtime.Tests/TestApplicationModules.cs
+++ b/Assets/UGF.Application.Runtime.Tests/TestApplicationModules.cs
@@ -33,7 +33,7 @@ namespace UGF.Application.Runtime.Tests
             private readonly Action m_init;
             private readonly Action m_uninit;
 
-            protected ModuleBase(Type type, IApplication application, Action init = null, Action uninit = null) : base(new ApplicationModuleDescription(type), application)
+            protected ModuleBase(Type type, IApplication application, Action init = null, Action uninit = null) : base(new ApplicationModuleDescription { RegisterType = type }, application)
             {
                 m_init = init;
                 m_uninit = uninit;

--- a/Assets/UGF.Application.Runtime.Tests/TestDescribedModuleAsset.cs
+++ b/Assets/UGF.Application.Runtime.Tests/TestDescribedModuleAsset.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace UGF.Application.Runtime.Tests
 {
@@ -8,7 +7,10 @@ namespace UGF.Application.Runtime.Tests
     {
         protected override IApplicationModuleDescription OnBuildDescription()
         {
-            return new TestModuleDescription(typeof(TestDescribedModule));
+            return new TestModuleDescription
+            {
+                RegisterType = typeof(TestDescribedModule)
+            };
         }
 
         protected override TestDescribedModule OnBuild(TestModuleDescription description, IApplication application)
@@ -26,8 +28,5 @@ namespace UGF.Application.Runtime.Tests
 
     public class TestModuleDescription : ApplicationModuleDescription
     {
-        public TestModuleDescription(Type registerType) : base(registerType)
-        {
-        }
     }
 }

--- a/Packages/UGF.Application/Runtime/ApplicationModuleAsset`1.cs
+++ b/Packages/UGF.Application/Runtime/ApplicationModuleAsset`1.cs
@@ -4,7 +4,10 @@
     {
         protected override IApplicationModuleDescription OnBuildDescription()
         {
-            return new ApplicationModuleDescription(typeof(TModule));
+            return new ApplicationModuleDescription
+            {
+                RegisterType = typeof(TModule)
+            };
         }
     }
 }

--- a/Packages/UGF.Application/Runtime/ApplicationModuleDescription.Deprecated.cs
+++ b/Packages/UGF.Application/Runtime/ApplicationModuleDescription.Deprecated.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace UGF.Application.Runtime
+{
+    public partial class ApplicationModuleDescription
+    {
+        [Obsolete("ApplicationModuleDescription constructor with 'registerType' argument has been deprecated. Use default constructor and properties initialization instead.")]
+        public ApplicationModuleDescription(Type registerType)
+        {
+            RegisterType = registerType ?? throw new ArgumentNullException(nameof(registerType));
+        }
+    }
+}

--- a/Packages/UGF.Application/Runtime/ApplicationModuleDescription.Deprecated.cs.meta
+++ b/Packages/UGF.Application/Runtime/ApplicationModuleDescription.Deprecated.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8df24a8a813240da82b44c58a9928ac3
+timeCreated: 1610727087

--- a/Packages/UGF.Application/Runtime/ApplicationModuleDescription.cs
+++ b/Packages/UGF.Application/Runtime/ApplicationModuleDescription.cs
@@ -2,17 +2,12 @@
 
 namespace UGF.Application.Runtime
 {
-    public class ApplicationModuleDescription : IApplicationModuleDescription
+    public partial class ApplicationModuleDescription : IApplicationModuleDescription
     {
         public Type RegisterType { get; set; }
 
         public ApplicationModuleDescription()
         {
-        }
-
-        public ApplicationModuleDescription(Type registerType)
-        {
-            RegisterType = registerType ?? throw new ArgumentNullException(nameof(registerType));
         }
     }
 }


### PR DESCRIPTION
- Deprecate `ApplicationModuleDescription` constructor with `registerType` argument, use default constructor and property initialization to specify register type.