### PR TITLE
Fix ApplicationConfigProjectAsset does not open project settings

### DIFF
--- a/Packages/UGF.Application/Editor/ApplicationConfigProjectAssetEditor.cs
+++ b/Packages/UGF.Application/Editor/ApplicationConfigProjectAssetEditor.cs
@@ -21,7 +21,7 @@ namespace UGF.Application.Editor
 
                 if (GUILayout.Button("Open Application Project Settings", GUILayout.Width(250F)))
                 {
-                    SettingsService.OpenProjectSettings("Project/UGF/Application");
+                    SettingsService.OpenProjectSettings("Project/Unity Game Framework/Application");
                 }
 
                 GUILayout.FlexibleSpace();


### PR DESCRIPTION
- Fix `ApplicationConfigProjectAsset` to open _Application_ section in _ProjectSettings_ with `Open Application Project Settings` button in inspector of the asset.