### PR TITLE
Fix application singleton to inherit configured builders

### DIFF
--- a/Packages/UGF.Application/Runtime/ApplicationSingletonBuilder.cs
+++ b/Packages/UGF.Application/Runtime/ApplicationSingletonBuilder.cs
@@ -1,6 +1,6 @@
 ﻿namespace UGF.Application.Runtime
 {
-    public class ApplicationSingletonBuilder : ApplicationOrderedBuilder
+    public class ApplicationSingletonBuilder : ApplicationConfiguredBuilder
     {
         public bool ProvideStaticInstance { get; set; } = true;
 

--- a/Packages/UGF.Application/Runtime/ApplicationSingletonBuilderComponent.cs
+++ b/Packages/UGF.Application/Runtime/ApplicationSingletonBuilderComponent.cs
@@ -3,7 +3,7 @@
 namespace UGF.Application.Runtime
 {
     [AddComponentMenu("Unity Game Framework/Application/Application Singleton Builder", 2000)]
-    public class ApplicationSingletonBuilderComponent : ApplicationOrderedBuilderComponent
+    public class ApplicationSingletonBuilderComponent : ApplicationConfiguredBuilderComponent
     {
         [SerializeField] private bool m_provideStaticInstance = true;
 

--- a/Packages/UGF.Application/package.json
+++ b/Packages/UGF.Application/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "com.ugf.initialize": "2.6.0",
     "com.ugf.description": "2.0.0",
-    "com.ugf.runtimetools": "2.0.0",
+    "com.ugf.runtimetools": "2.2.0",
     "com.ugf.logs": "5.1.4"
   }
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.ide.rider": "3.0.7",
-    "com.unity.test-framework": "1.1.24"
+    "com.unity.test-framework": "1.1.27"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "com.ugf.initialize": "2.6.0",
         "com.ugf.description": "2.0.0",
-        "com.ugf.runtimetools": "2.0.0",
+        "com.ugf.runtimetools": "2.2.0",
         "com.ugf.logs": "5.1.4"
       }
     },
@@ -71,7 +71,7 @@
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.runtimetools": {
-      "version": "2.0.0",
+      "version": "2.2.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {},

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -94,7 +94,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.24",
+      "version": "1.1.27",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.1.7f1
-m_EditorVersionWithRevision: 2021.1.7f1 (d91830b65d9b)
+m_EditorVersion: 2021.1.15f1
+m_EditorVersionWithRevision: 2021.1.15f1 (e767a7370072)


### PR DESCRIPTION
- Update dependencies: `com.ugf.runtimetools` to `2.2.0` version.
- Fix `ApplicationSingletonBuilder` class to inherit from `ApplicationConfiguredBuilder` class.
- Fix `ApplicationSingletonBuilderComponent ` class to inherit from `ApplicationConfiguredBuilderComponent` class.