### PR TITLE
Add GameObject.GetApplication extension method

### DIFF
--- a/Packages/UGF.Application/Editor/ApplicationConfigAssetEditor.cs
+++ b/Packages/UGF.Application/Editor/ApplicationConfigAssetEditor.cs
@@ -2,20 +2,15 @@ using UGF.Application.Runtime;
 using UGF.EditorTools.Editor.IMGUI;
 using UGF.EditorTools.Editor.IMGUI.EnabledProperty;
 using UnityEditor;
-using UnityEditorInternal;
 
 namespace UGF.Application.Editor
 {
     [CustomEditor(typeof(ApplicationConfigAsset), true)]
     internal class ApplicationConfigAssetEditor : UnityEditor.Editor
     {
-        private readonly EditorDrawer m_drawer = new EditorDrawer
-        {
-            DisplayTitlebar = true
-        };
-
         private SerializedProperty m_propertyScript;
         private EnabledPropertyListDrawer m_list;
+        private ReorderableListSelectionDrawerByPath m_listSelection;
 
         private void OnEnable()
         {
@@ -24,16 +19,23 @@ namespace UGF.Application.Editor
             SerializedProperty propertyModules = serializedObject.FindProperty("m_modules");
 
             m_list = new EnabledPropertyListDrawer(propertyModules);
-            m_list.List.onSelectCallback = OnSelect;
+
+            m_listSelection = new ReorderableListSelectionDrawerByPath(m_list, "m_value")
+            {
+                Drawer =
+                {
+                    DisplayTitlebar = true
+                }
+            };
 
             m_list.Enable();
-            m_drawer.Disable();
+            m_listSelection.Enable();
         }
 
         private void OnDisable()
         {
             m_list.Disable();
-            m_drawer.Disable();
+            m_listSelection.Disable();
         }
 
         public override void OnInspectorGUI()
@@ -46,38 +48,13 @@ namespace UGF.Application.Editor
             }
 
             m_list.DrawGUILayout();
+            m_listSelection.DrawGUILayout();
 
             serializedObject.ApplyModifiedProperties();
 
-            if (m_drawer.HasEditor)
-            {
-                m_drawer.DrawGUILayout();
-            }
-            else
+            if (!m_listSelection.Drawer.HasEditor)
             {
                 EditorGUILayout.HelpBox("Select any module to display.", MessageType.Info);
-            }
-        }
-
-        private void OnSelect(ReorderableList list)
-        {
-            if (list.index >= 0 && list.index < list.count)
-            {
-                SerializedProperty propertyElement = m_list.SerializedProperty.GetArrayElementAtIndex(list.index);
-                SerializedProperty propertyModule = propertyElement.FindPropertyRelative("m_value");
-
-                if (propertyModule.objectReferenceValue != null)
-                {
-                    m_drawer.Set(propertyModule.objectReferenceValue);
-                }
-                else
-                {
-                    m_drawer.Clear();
-                }
-            }
-            else
-            {
-                m_drawer.Clear();
             }
         }
     }

--- a/Packages/UGF.Application/Editor/ApplicationConfigProjectAssetEditor.cs
+++ b/Packages/UGF.Application/Editor/ApplicationConfigProjectAssetEditor.cs
@@ -10,8 +10,7 @@ namespace UGF.Application.Editor
         public override void OnInspectorGUI()
         {
             EditorGUILayout.Space();
-            EditorGUILayout.HelpBox("This is Application Project Config Resource asset " +
-                                    "which can be specified in Application Launcher Resources component to load config from project settings during initialization.", MessageType.Info);
+            EditorGUILayout.HelpBox("This is Application Project Config Resource asset which can be specified in Application Launcher Resources component to load config from project settings during initialization.", MessageType.Info);
 
             EditorGUILayout.Space();
 

--- a/Packages/UGF.Application/Runtime/ApplicationGameObjectExtensions.cs
+++ b/Packages/UGF.Application/Runtime/ApplicationGameObjectExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using UGF.RuntimeTools.Runtime.Providers;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace UGF.Application.Runtime
+{
+    public static class ApplicationGameObjectExtensions
+    {
+        public static IApplication GetApplication(this GameObject gameObject)
+        {
+            return TryGetApplication(gameObject, out IApplication application) ? application : throw new ArgumentException($"Application not found by the specified gameobject: '{gameObject}'.");
+        }
+
+        public static bool TryGetApplication(this GameObject gameObject, out IApplication application)
+        {
+            if (gameObject == null) throw new ArgumentNullException(nameof(gameObject));
+
+            var provider = ProviderInstance.Get<IProvider<Scene, IApplication>>();
+
+            return provider.TryGet(gameObject.scene, out application);
+        }
+    }
+}

--- a/Packages/UGF.Application/Runtime/ApplicationGameObjectExtensions.cs.meta
+++ b/Packages/UGF.Application/Runtime/ApplicationGameObjectExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d49c1ba942954ff8ad479181d204f4d2
+timeCreated: 1637691919

--- a/Packages/UGF.Application/package.json
+++ b/Packages/UGF.Application/package.json
@@ -2,7 +2,7 @@
   "name": "com.ugf.application",
   "displayName": "UGF.Application",
   "version": "8.0.0-preview.9",
-  "unity": "2021.1",
+  "unity": "2021.2",
   "apiCompatibility": ".NET Standard 2.0",
   "description": "Provides an entry point of the application with modules initialization.",
   "author": {

--- a/Packages/UGF.Application/package.json
+++ b/Packages/UGF.Application/package.json
@@ -19,9 +19,11 @@
     "registry": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
   },
   "dependencies": {
-    "com.ugf.initialize": "2.6.0",
+    "com.ugf.initialize": "2.7.0",
     "com.ugf.description": "2.0.0",
-    "com.ugf.runtimetools": "2.2.0",
-    "com.ugf.logs": "5.1.4"
+    "com.ugf.runtimetools": "2.4.0",
+    "com.ugf.logs": "5.2.0",
+    "com.ugf.editortools": "2.1.0",
+    "com.ugf.builder": "2.0.1"
   }
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.ide.rider": "3.0.7",
-    "com.unity.test-framework": "1.1.27"
+    "com.unity.test-framework": "1.1.30"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -5,15 +5,17 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.ugf.initialize": "2.6.0",
+        "com.ugf.initialize": "2.7.0",
         "com.ugf.description": "2.0.0",
-        "com.ugf.runtimetools": "2.2.0",
-        "com.ugf.logs": "5.1.4"
+        "com.ugf.runtimetools": "2.4.0",
+        "com.ugf.logs": "5.2.0",
+        "com.ugf.editortools": "2.1.0",
+        "com.ugf.builder": "2.0.1"
       }
     },
     "com.ugf.builder": {
-      "version": "2.0.0",
-      "depth": 2,
+      "version": "2.0.1",
+      "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
@@ -29,12 +31,12 @@
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.defines": {
-      "version": "2.1.4",
+      "version": "2.1.5",
       "depth": 2,
       "source": "registry",
       "dependencies": {
         "com.ugf.customsettings": "3.4.1",
-        "com.ugf.editortools": "1.11.0"
+        "com.ugf.editortools": "1.13.0"
       },
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
@@ -48,30 +50,30 @@
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.editortools": {
-      "version": "1.11.0",
-      "depth": 3,
+      "version": "2.1.0",
+      "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.initialize": {
-      "version": "2.6.0",
+      "version": "2.7.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.logs": {
-      "version": "5.1.4",
+      "version": "5.2.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.ugf.defines": "2.1.4"
+        "com.ugf.defines": "2.1.5"
       },
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.runtimetools": {
-      "version": "2.2.0",
+      "version": "2.4.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {},

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -94,7 +94,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.27",
+      "version": "1.1.30",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/MemorySettings.asset
+++ b/ProjectSettings/MemorySettings.asset
@@ -1,0 +1,35 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!387306366 &1
+MemorySettings:
+  m_ObjectHideFlags: 0
+  m_EditorMemorySettings:
+    m_MainAllocatorBlockSize: -1
+    m_ThreadAllocatorBlockSize: -1
+    m_MainGfxBlockSize: -1
+    m_ThreadGfxBlockSize: -1
+    m_CacheBlockSize: -1
+    m_TypetreeBlockSize: -1
+    m_ProfilerBlockSize: -1
+    m_ProfilerEditorBlockSize: -1
+    m_BucketAllocatorGranularity: -1
+    m_BucketAllocatorBucketsCount: -1
+    m_BucketAllocatorBlockSize: -1
+    m_BucketAllocatorBlockCount: -1
+    m_ProfilerBucketAllocatorGranularity: -1
+    m_ProfilerBucketAllocatorBucketsCount: -1
+    m_ProfilerBucketAllocatorBlockSize: -1
+    m_ProfilerBucketAllocatorBlockCount: -1
+    m_TempAllocatorSizeMain: -1
+    m_JobTempAllocatorBlockSize: -1
+    m_BackgroundJobTempAllocatorBlockSize: -1
+    m_JobTempAllocatorReducedBlockSize: -1
+    m_TempAllocatorSizeGIBakingWorker: -1
+    m_TempAllocatorSizeNavMeshWorker: -1
+    m_TempAllocatorSizeAudioWorker: -1
+    m_TempAllocatorSizeCloudWorker: -1
+    m_TempAllocatorSizeGfx: -1
+    m_TempAllocatorSizeJobWorker: -1
+    m_TempAllocatorSizeBackgroundWorker: -1
+    m_TempAllocatorSizePreloadManager: -1
+  m_PlatformMemorySettings: {}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -3,7 +3,7 @@
 --- !u!129 &1
 PlayerSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 21
+  serializedVersion: 23
   productGUID: 7c19d94e2fdbc244e88c2c8640c81325
   AndroidProfiler: 0
   AndroidFilterTouchesWhenObscured: 0
@@ -68,6 +68,12 @@ PlayerSettings:
   androidRenderOutsideSafeArea: 0
   androidUseSwappy: 0
   androidBlitType: 0
+  androidResizableWindow: 0
+  androidDefaultWindowWidth: 1920
+  androidDefaultWindowHeight: 1080
+  androidMinimumWindowWidth: 400
+  androidMinimumWindowHeight: 300
+  androidFullscreenMode: 1
   defaultIsNativeResolution: 1
   macRetinaSupport: 1
   runInBackground: 1
@@ -121,6 +127,7 @@ PlayerSettings:
   vulkanEnableSetSRGBWrite: 0
   vulkanEnablePreTransform: 0
   vulkanEnableLateAcquireNextImage: 0
+  vulkanEnableCommandBufferRecycling: 1
   m_SupportedAspectRatios:
     4:3: 1
     5:4: 1
@@ -153,7 +160,7 @@ PlayerSettings:
     tvOS: 0
   overrideDefaultApplicationIdentifier: 0
   AndroidBundleVersionCode: 1
-  AndroidMinSdkVersion: 19
+  AndroidMinSdkVersion: 22
   AndroidTargetSdkVersion: 0
   AndroidPreferredInstallLocation: 1
   aotOptions: 
@@ -209,11 +216,13 @@ PlayerSettings:
   iOSLaunchScreeniPadCustomStoryboardPath: 
   iOSDeviceRequirements: []
   iOSURLSchemes: []
+  macOSURLSchemes: []
   iOSBackgroundModes: 0
   iOSMetalForceHardShadows: 0
   metalEditorSupport: 1
   metalAPIValidation: 1
   iOSRenderExtraFrameOnPause: 0
+  iosCopyPluginsCodeInsteadOfSymlink: 0
   appleDeveloperTeamID: 
   iOSManualSigningProvisioningProfileID: 
   tvOSManualSigningProvisioningProfileID: 
@@ -223,6 +232,7 @@ PlayerSettings:
   iOSRequireARKit: 0
   iOSAutomaticallyDetectAndAddCapabilities: 1
   appleEnableProMotion: 0
+  shaderPrecisionModel: 0
   clonedFromGUID: c0afd0d1d80e3634a9dac47e8a0426ea
   templatePackageId: com.unity.template.3d@1.0.11
   templateDefaultScene: Assets/Scenes/SampleScene.unity
@@ -234,6 +244,7 @@ PlayerSettings:
   useCustomGradlePropertiesTemplate: 0
   useCustomProguardFile: 0
   AndroidTargetArchitectures: 1
+  AndroidTargetDevices: 0
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
   AndroidKeystoreName: '{inproject}: '
@@ -250,13 +261,203 @@ PlayerSettings:
     height: 180
     banner: {fileID: 0}
   androidGamepadSupportLevel: 0
+  chromeosInputEmulation: 1
   AndroidMinifyWithR8: 0
   AndroidMinifyRelease: 0
   AndroidMinifyDebug: 0
   AndroidValidateAppBundleSize: 1
   AndroidAppBundleSizeToValidate: 150
   m_BuildTargetIcons: []
-  m_BuildTargetPlatformIcons: []
+  m_BuildTargetPlatformIcons:
+  - m_BuildTarget: iPhone
+    m_Icons:
+    - m_Textures: []
+      m_Width: 180
+      m_Height: 180
+      m_Kind: 0
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 120
+      m_Height: 120
+      m_Kind: 0
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 167
+      m_Height: 167
+      m_Kind: 0
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 152
+      m_Height: 152
+      m_Kind: 0
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 76
+      m_Height: 76
+      m_Kind: 0
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 120
+      m_Height: 120
+      m_Kind: 3
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 80
+      m_Height: 80
+      m_Kind: 3
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 80
+      m_Height: 80
+      m_Kind: 3
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 40
+      m_Height: 40
+      m_Kind: 3
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 87
+      m_Height: 87
+      m_Kind: 1
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 58
+      m_Height: 58
+      m_Kind: 1
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 29
+      m_Height: 29
+      m_Kind: 1
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 58
+      m_Height: 58
+      m_Kind: 1
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 29
+      m_Height: 29
+      m_Kind: 1
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 60
+      m_Height: 60
+      m_Kind: 2
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 40
+      m_Height: 40
+      m_Kind: 2
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 40
+      m_Height: 40
+      m_Kind: 2
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 20
+      m_Height: 20
+      m_Kind: 2
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 1024
+      m_Height: 1024
+      m_Kind: 4
+      m_SubKind: App Store
+  - m_BuildTarget: Android
+    m_Icons:
+    - m_Textures: []
+      m_Width: 432
+      m_Height: 432
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 324
+      m_Height: 324
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 216
+      m_Height: 216
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 162
+      m_Height: 162
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 108
+      m_Height: 108
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 81
+      m_Height: 81
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 192
+      m_Height: 192
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 144
+      m_Height: 144
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 96
+      m_Height: 96
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 72
+      m_Height: 72
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 48
+      m_Height: 48
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 36
+      m_Height: 36
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 192
+      m_Height: 192
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 144
+      m_Height: 144
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 96
+      m_Height: 96
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 72
+      m_Height: 72
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 48
+      m_Height: 48
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 36
+      m_Height: 36
+      m_Kind: 0
+      m_SubKind: 
   m_BuildTargetBatching:
   - m_BuildTarget: Standalone
     m_StaticBatching: 1
@@ -308,7 +509,7 @@ PlayerSettings:
   m_BuildTargetGraphicsAPIs:
   - m_BuildTarget: AndroidPlayer
     m_APIs: 150000000b000000
-    m_Automatic: 0
+    m_Automatic: 1
   - m_BuildTarget: iOSSupport
     m_APIs: 10000000
     m_Automatic: 1
@@ -335,6 +536,7 @@ PlayerSettings:
   m_BuildTargetGroupLightmapEncodingQuality: []
   m_BuildTargetGroupLightmapSettings: []
   m_BuildTargetNormalMapEncoding: []
+  m_BuildTargetDefaultTextureCompressionFormat: []
   playModeTestRunnerEnabled: 0
   runPlayModeTestAsEditModeTest: 0
   actionOnDotNetUnhandledException: 1
@@ -344,6 +546,7 @@ PlayerSettings:
   cameraUsageDescription: 
   locationUsageDescription: 
   microphoneUsageDescription: 
+  bluetoothUsageDescription: 
   switchNMETAOverride: 
   switchNetLibKey: 
   switchSocketMemoryPoolSize: 6144
@@ -352,6 +555,7 @@ PlayerSettings:
   switchScreenResolutionBehavior: 2
   switchUseCPUProfiler: 0
   switchUseGOLDLinker: 0
+  switchLTOSetting: 0
   switchApplicationID: 0x01004b9000490000
   switchNSODependencies: 
   switchTitleNames_0: 
@@ -369,6 +573,7 @@ PlayerSettings:
   switchTitleNames_12: 
   switchTitleNames_13: 
   switchTitleNames_14: 
+  switchTitleNames_15: 
   switchPublisherNames_0: 
   switchPublisherNames_1: 
   switchPublisherNames_2: 
@@ -384,6 +589,7 @@ PlayerSettings:
   switchPublisherNames_12: 
   switchPublisherNames_13: 
   switchPublisherNames_14: 
+  switchPublisherNames_15: 
   switchIcons_0: {fileID: 0}
   switchIcons_1: {fileID: 0}
   switchIcons_2: {fileID: 0}
@@ -399,6 +605,7 @@ PlayerSettings:
   switchIcons_12: {fileID: 0}
   switchIcons_13: {fileID: 0}
   switchIcons_14: {fileID: 0}
+  switchIcons_15: {fileID: 0}
   switchSmallIcons_0: {fileID: 0}
   switchSmallIcons_1: {fileID: 0}
   switchSmallIcons_2: {fileID: 0}
@@ -414,6 +621,7 @@ PlayerSettings:
   switchSmallIcons_12: {fileID: 0}
   switchSmallIcons_13: {fileID: 0}
   switchSmallIcons_14: {fileID: 0}
+  switchSmallIcons_15: {fileID: 0}
   switchManualHTML: 
   switchAccessibleURLs: 
   switchLegalInformation: 
@@ -477,6 +685,10 @@ PlayerSettings:
   switchNetworkInterfaceManagerInitializeEnabled: 1
   switchPlayerConnectionEnabled: 1
   switchUseNewStyleFilepaths: 0
+  switchUseMicroSleepForYield: 1
+  switchEnableRamDiskSupport: 0
+  switchMicroSleepForYieldTime: 25
+  switchRamDiskSpaceSize: 12
   ps4NPAgeRating: 12
   ps4NPTitleSecret: 
   ps4NPTrophyPackPath: 
@@ -572,20 +784,22 @@ PlayerSettings:
   webGLThreadsSupport: 0
   webGLDecompressionFallback: 0
   scriptingDefineSymbols:
-    1: 
+    Standalone: 
+  additionalCompilerArguments: {}
   platformArchitecture: {}
   scriptingBackend:
     Standalone: 1
   il2cppCompilerConfiguration: {}
   managedStrippingLevel: {}
   incrementalIl2cppBuild: {}
+  suppressCommonWarnings: 1
   allowUnsafeCode: 0
   useDeterministicCompilation: 1
-  useReferenceAssemblies: 1
   enableRoslynAnalyzers: 1
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 1
   gcIncremental: 0
+  assemblyVersionValidation: 1
   gcWBarrierValidation: 0
   apiCompatibilityLevelPerPlatform: {}
   m_RenderingPath: 1
@@ -634,6 +848,7 @@ PlayerSettings:
   XboxOneCapability: []
   XboxOneGameRating: {}
   XboxOneIsContentPackage: 0
+  XboxOneEnhancedXboxCompatibilityMode: 0
   XboxOneEnableGPUVariability: 0
   XboxOneSockets: {}
   XboxOneSplashScreen: {fileID: 0}
@@ -665,4 +880,7 @@ PlayerSettings:
   organizationId: 
   cloudEnabled: 0
   legacyClampBlendShapeWeights: 1
+  playerDataPath: 
+  forceSRGBBlit: 1
   virtualTexturingSupportEnabled: 0
+  uploadClearedTextureDataAfterCreationFromScript: 1

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.1.15f1
-m_EditorVersionWithRevision: 2021.1.15f1 (e767a7370072)
+m_EditorVersion: 2021.2.3f1
+m_EditorVersionWithRevision: 2021.2.3f1 (32358a8527b4)


### PR DESCRIPTION
- Update package _Unity_ version to `2021.2`.
- Update dependencies: `com.ugf.initialize` to `2.7.0`, `com.ugf.runtimetools` to `2.4.0`, `com.ugf.logs` to `5.2.0`, `com.ugf.editortools` to `2.1.0` and `com.ugf.builder` to `2.0.1`. 
- Add `GameObject.TryGetApplication()` extension method to get access to application connected to scene of the specified _GameObject_.